### PR TITLE
Fluent API; OAuth further implementation; removing req on config()

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ HaPi – Harvest API
 
 Fork of `gridonic/hapi` PHP Wrapper Library for the Harvest API. Adds the use of oAuth Tokens.
 
-Caution - Deprication Coming - January 1st, 2019
+Caution - Deprecation Coming - January 1st, 2019
 -----
-Please be aware, this implementation appears to be version 1 of Harvest's API. Harvest has depricated it.
+Please be aware, this implementation appears to be version 1 of Harvest's API. Harvest has deprecated it.
 We will have to update it to version 2 in the near future.
 API documentation is avaible for
 [Version 1](https://help.getharvest.com/api-v1/) and
@@ -19,9 +19,11 @@ Installation
 
 This package includes `tightenco\collect` a standalone version of `Illuminate\Support\Collection` used in Laravel.
 
-Important Notes
------
-> Currently this is mostly to be used with Laravel 5. It relies on the config helper function in the HarvestAPI file, so you have to have config settings in your services.php for harvest.
+### Configuration
+
+You can either configure this as a Laravel service or as a standalone library:
+
+#### Laravel service
 
 Add this to the array in `config/services.php`:
 ```
@@ -39,11 +41,26 @@ HARVEST_SECRET=
 HARVEST_CALLBACK=
 ```
 
+#### Standalone library
+
+Simply store the CLIENT_ID and CLIENT_SECRET somewhere safe (you'll probably have some sort of
+config or env file in your app, right?), and add them like this:
+
+```php
+$harvest = (new Harvest\HarvestAPI)
+	->setClientId(HARVEST_CLIENT_ID)
+	->setClientSecret(HARVEST_CLIENT_SECRET)
+	->setAccount(HARVEST_ACCOUNT);
+```
 
 Usage
 -----
 
-#### Example Controller Use
+### Example OAuth2 authentication
+TODO. Redirect your user to `$harvest->getAuthorizeUrl()` and store the final token from 
+`$harvest->accessToken($code)` somewhere safe. It will be used for all other calls.
+
+### Example Controller Use
 ```
 $token = App\ServiceToken::find(6);
     

--- a/src/Harvest/HarvestApi.php
+++ b/src/Harvest/HarvestApi.php
@@ -2655,7 +2655,8 @@ class HarvestApi
         if ($this->refreshingToken) {
             curl_setopt($ch, CURLOPT_URL, "https://api.harvestapp.com/$url");
         } elseif ($this->token) {
-            $url = $url . '?access_token=' . $this->token;
+            $qs_token = 'access_token=' . $this->token;
+            $url = $url . (strpos($url, '?') === false? '?' : '&') . $qs_token;
             $account = $this->account?: 'api';
             curl_setopt($ch, CURLOPT_URL, "https://$account.harvestapp.com/$url");
         } else {

--- a/src/Harvest/Model/Result.php
+++ b/src/Harvest/Model/Result.php
@@ -1,6 +1,4 @@
 <?php
-
-
 namespace Harvest\Model;
 
 use Harvest\Exception\HarvestException;
@@ -15,25 +13,21 @@ use Harvest\Exception\HarvestException;
 /**
  * Harvest Result Object
  *
- * <b>Properties</b>
- * <ul>
- *   <li>code</li>
- *   <li>data</li>
- *   <li>Server</li>
- *   <li>Date</li>
- *   <li>Content-Type</li>
- *   <li>Connection</li>
- *   <li>Status</li>
- *   <li>X-Powered-By</li>
- *   <li>ETag</li>
- *   <li>X-Served-From</li>
- *   <li>X-Runtime</li>
- *   <li>Content-Length</li>
- *   <li>Location</li>
- *   <li>Hint</li>
- * </ul>
- *
+ * @property int code
  * @property array|mixed data
+ *
+ * @property string Server
+ * @property string Date
+ * @property string Content-Type
+ * @property string Connection
+ * @property string Status
+ * @property string X-Powered-By
+ * @property string ETag
+ * @property string X-Served-From
+ * @property string X-Runtime
+ * @property string Content-Length
+ * @property string Location
+ * @property string Hint
  */
 class Result
 {
@@ -165,3 +159,4 @@ class Result
     }
 
 }
+


### PR DESCRIPTION
- Removing hard requirement on `config()`
- setting `setAccount()` as fluent as well
- and _actually_ implementing the rest of OAuth2 support (returning Authorize URL for redirect and retrieving the final token)